### PR TITLE
Add pagination support in cite shortcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /bower_components/
 /node_modules/
 .DS_Store
-exampleSite
+docs

--- a/README.md
+++ b/README.md
@@ -170,7 +170,16 @@ Thanks to Hugo’s [`getJSON`](https://gohugo.io/templates/data-templates/#data-
 ### Render in-text citations
 
 Use the `{{< cite >}}` shortcode to render rich in-text citations.
-The citation key must match the `id` field of a reference in your CSL-JSON file.
+
+Example:
+
+```markdown
+<!-- Markdown -->
+
+{{< cite "Lessig 2002" >}}
+```
+
+The citation key (in the above example, `Lessig 2002`) must match the `id` field of a reference in your CSL-JSON file.
 You can make it look like an author-date format, or anything else.
 
 Here’s an excerpt of a CSL-JSON file:
@@ -197,6 +206,30 @@ Using the citation key defined in the CSL-JSON, you can reference your entry in 
 Our generation has a philosopher.
 He is not an artist, or a professional writer.
 He is a programmer. {{< cite "Lessig 2002" >}}
+
+#### Cite a Page
+
+You can also provide a **page** as the second positional parameter:
+
+```markdown
+<!-- Markdown -->
+
+{{< cite "Lessig 2002" 5 >}}
+```
+
+The example above will render `(Lessig, 2020, p. 5)` (note the `p.` was added by Hugo Cite; you need not to add it).
+
+#### Cite a Page Range
+
+You can instead specify a **range of pages** using a **dash** `-`, which will output `pp.` before the page range (ensure there is no space between the page numbers):
+
+```markdown
+<!-- Markdown -->
+
+{{< cite "Lessig 2002" 5-6 >}}
+```
+
+The example above will render `(Lessig, 2020, pp. 5-6)`.
 
 ## Cited Works
 

--- a/layouts/shortcodes/cite.html
+++ b/layouts/shortcodes/cite.html
@@ -25,19 +25,24 @@
 
 */}}
 
-{{- $errorMissingValue := "1 or 2 values must be supplied with this shortcode. The first is required and should match an ID in the CSL-JSON bibliogrpahy file, the second is optional, and should be a page number or range of page numbers. Example: {{< cite &#34;Faure 1909&#34; &#34;304&#34; >}}" -}}
+{{- $errorMissingValue := "1 or 2 values must be supplied with this shortcode. You provided %d params. The first is required and should match an ID in the CSL-JSON bibliogrpahy file, the second is optional, and should be a page number or range of page numbers. Example: {{< cite \"Faure 1909\" \"304\" >}}" -}}
 
 {{- $defaultErrString := "No matching ID was found for `%s` in the references. Please make sure to provide an available ID in your `bib.json` file." -}}
 
-
 {{- if and (ne (len .Params) 1) (ne (len .Params) 2) -}}
-{{- errorf $errorMissingValue -}}
+{{- errorf $errorMissingValue (len .Params) -}}
 {{- else -}}
 {{- $id := .Get 0 -}}
 {{- $pages := .Get 1 -}}
+{{- if $pages -}}
+{{- $pages = string $pages -}}
+{{- end -}}
+{{- $formatedPages := (printf "p.&nbsp;%s" $pages) | safeHTML -}}
+  {{- if gt (findRE "-" $pages) 0 -}}{{/* If `$pages` contains a dash */}}
+  {{- $formatedPages = (printf "pp.&nbsp;%s" $pages) | safeHTML -}}
+  {{- end -}}
 
 {{/* -------------------- BEGIN Citation style -------------------- */}}
-
 {{- $citationStyle := "apa" }}
 {{- if $.Site.Params.citationStyle }}
   {{- if templates.Exists (printf "aprtials/bibliography/%s-style.html" $.Site.Params.citationStyle) }}
@@ -64,7 +69,7 @@
 {{- $bibliographyPath = $.Page.Params.bibFile -}}
 {{- end }}
 
-{{ if gt (len $bibliographyPath) 0 }}{{/* Begin Bibliography Loop */}}
+{{- if gt (len $bibliographyPath) 0 -}}{{/* Begin Bibliography Loop */}}
 {{- $bibliography := getJSON $bibliographyPath -}}
 {{/* -------------------- END Bibliography path -------------------- */}}
 
@@ -110,7 +115,7 @@
       {{- end -}}
       {{- end -}}
       {{- end -}}
-      {{- with $pages -}},&#32;pp.&nbsp;{{ . }}{{- end -}}
+      {{- with $pages -}},&#32;{{ $formatedPages }}{{- end -}}
     </a>)
     <span class="hugo-cite-citation">{{ partial $partialPath $currentRef }}</span></span>
 


### PR DESCRIPTION
Differentiate a single page (p. 5) and a
range of pages (pp. 5-6).

Reflect changes in README documentation.

Closes #9