### PR TITLE
remove unwanted space after cite shortcode

### DIFF
--- a/layouts/shortcodes/cite.html
+++ b/layouts/shortcodes/cite.html
@@ -191,4 +191,4 @@
 
     {{- end -}}
     {{- /* END loop over keys*/ -}}
-    )</span>
+    )</span> {{- "" -}}


### PR DESCRIPTION
Something that bothered me for quite some time. Hugo adds a space after using a shortcode. In most cases it's okay, but using the cite shortcode at the end of a sentence adds a space before the period which is annoying. 

before making the change to `shortcodes/cite.html`:

![image](https://user-images.githubusercontent.com/54182533/208316050-9b5005ec-2c0e-4569-a783-d6e326da5f87.png)

after making the change to `shortcodes/cite.html`:

![image](https://user-images.githubusercontent.com/54182533/208316106-7c16baec-95f1-432a-a1ce-ccf91c93274c.png)
