### PR TITLE
getJSON deprecated; replace with resources.Get

### DIFF
--- a/layouts/shortcodes/cite.html
+++ b/layouts/shortcodes/cite.html
@@ -96,7 +96,10 @@
 {{- end }}
 
 {{- if gt (len $bibliographyPath) 0 -}}{{/* Begin Bibliography Loop */}}
-{{- $bibliography := getJSON $bibliographyPath -}}
+{{ $bibliography := dict }}
+{{ with resources.Get $bibliographyPath }}
+  {{ $bibliography = . | transform.Unmarshal }}
+{{ end }}
 {{- /* -------------------- END Bibliography path -------------------- */ -}}
 
   <span class="hugo-cite-intext"


### PR DESCRIPTION
`getJSON` is deprecated in _Hugo 0.123.0_ see: https://gohugo.io/functions/data/getjson/

Recommended alternative: https://gohugo.io/functions/data/getjson/#global-resource-alternative

```hugo
{{ $p := "data/books.json" }}
{{ with resources.Get $p }}
  {{ $data = . | transform.Unmarshal }}
{{ else }}
```

Thank you for creating `hugo-cite` 🙇‍♂️ I am using it on https://github.com/whyboris/utilitarianism.net

I was inlining `{{< cite "Singer1972" >}}` over 500+ times across my markdown files and the compilation time was about 10 seconds. After moving to `resources.Get` the compilation is back to < 500ms 🚀 

I hope you can merge in this change ❤️ 

⚠️ looks like the `resources.Get` method requires the `json` file to be located in `/assets` 🤔 so we may need modification for this to work.